### PR TITLE
fix build error

### DIFF
--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,53 +1,7 @@
-import Projects from '@/src/components/projects'
-import SideBar from '@/src/components/side-bar'
-import { authOptions } from './api/auth/[...nextauth]'
-import useSWR from 'swr'
-import { fetcher } from '@/util/api'
-import { unstable_getServerSession } from 'next-auth/next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useState } from 'react'
-import { useBreakpointValue } from '@chakra-ui/react'
+import Page, { getServerSideProps as getServerSidePropsImported } from './projects/index'
 
-const smVariant = { navigation: 'drawer', navigationButton: true }
-const mdVariant = { navigation: 'sidebar', navigationButton: false }
+export default Page
 
-export default function Page ({ session }: { session: any, emailVerified: boolean }): JSX.Element {
-  const { data, error, mutate } = useSWR('/api/projects', fetcher)
-  const { data: industries, error: errorIndustries } = useSWR('/api/industries', fetcher)
-  const [isSidebarOpen, setSidebarOpen] = useState(false)
-  const variants = useBreakpointValue({ base: smVariant, md: mdVariant })
-
-  const toggleSidebar = () => setSidebarOpen(!isSidebarOpen)
-
-  return (
-    <SideBar
-      page='projects'
-      variant={variants?.navigation}
-      isOpen={isSidebarOpen}
-      onClose={toggleSidebar}
-      showSidebarButton={variants?.navigationButton}
-      onShowSidebar={toggleSidebar}
-    >
-      <Projects projects={data || []} session={session} fetchProjects={mutate} />
-    </SideBar>
-  )
-}
-
-export async function getServerSideProps (ctx): Promise<any> {
-  const session = await unstable_getServerSession(ctx.req, ctx.res, authOptions)
-
-  if (session?.user == null) {
-    return {
-      redirect: {
-        destination: '/login',
-        permanent: false
-      }
-    }
-  }
-  return {
-    props: {
-      session: JSON.parse(JSON.stringify(session)),
-      ...await serverSideTranslations(ctx.locale as string, ['buttons', 'navbar', 'placeholders', 'projects', 'settings', 'api-messages'])
-    }
-  }
+export async function getServerSideProps (context: any): Promise<any> {
+  return await getServerSidePropsImported(context)
 }

--- a/src/components/side-bar.tsx
+++ b/src/components/side-bar.tsx
@@ -16,7 +16,7 @@ import { useTranslation } from 'next-i18next'
 interface Props {
   page: string
   children: string | JSX.Element | JSX.Element[]
-  onClose: Function
+  onClose: () => void
   isOpen: boolean
   variant: 'drawer' | 'sidebar' | undefined | string
   showSidebarButton?: boolean
@@ -54,9 +54,6 @@ const SidebarContent = (props): JSX.Element => {
 }
 
 const SideBar = (props: Props): JSX.Element => {
-  const { t } = useTranslation()
-  const { page } = props
-
   return props.variant === 'sidebar'
     ? (
       <>


### PR DESCRIPTION
- removed duplicate code for `home` and `projects/index` page and fix the sidebar missing properties causing the build to fail
- removed some unused variables in the sidebar
- redefined the interface onClose function to not trigger a standardjs error anymore for type conficts in the sidebar component